### PR TITLE
Add support for sacrum markers

### DIFF
--- a/src/gias3/musculoskeletal/model_alignment.py
+++ b/src/gias3/musculoskeletal/model_alignment.py
@@ -616,7 +616,7 @@ def createPelvisACSISB(lasis, rasis, lpsis, rpsis):
     axes: x-anterior, y-superior, z-right
     """
     oa = (lasis + rasis) / 2.0
-    op = (lpsis + lpsis) / 2.0
+    op = (lpsis + rpsis) / 2.0
     # right
     z = normaliseVector(rasis - lasis)
     # anterior, in plane of op, rasis, lasis

--- a/src/gias3/musculoskeletal/model_alignment.py
+++ b/src/gias3/musculoskeletal/model_alignment.py
@@ -627,6 +627,22 @@ def createPelvisACSISB(lasis, rasis, lpsis, rpsis):
     return oa, x, y, z
 
 
+def createPelvisACSISB_sacr(lasis, rasis, sacr):
+    """Calculate the ISB pelvis anatomic coordinate system
+    axes: x-anterior, y-superior, z-right
+    """
+    oa = (lasis + rasis) / 2.0
+    op = sacr
+    # right
+    z = normaliseVector(rasis - lasis)
+    # anterior, in plane of op, rasis, lasis
+    n1 = normaliseVector(numpy.cross(rasis - op, lasis - op))
+    x = normaliseVector(numpy.cross(n1, z))
+    # superior
+    y = normaliseVector(numpy.cross(z, x))
+    return oa, x, y, z
+
+
 def createPelvisACSAPP(lasis, rasis, lpt, rpt):
     """Calculate the anterior pelvic plane anatomic
     coordinate system: x-right, y-anterior, z-superior


### PR DESCRIPTION
This PR adds some minimal support for aligning models to marker sets that contain a sacrum marker instead of two PSI markers.